### PR TITLE
[ZEE-4455] Allow to filter by package (file names)

### DIFF
--- a/templates/ssis.conf
+++ b/templates/ssis.conf
@@ -8,3 +8,25 @@ connection {
     #username=
     #password=
 }
+
+# Filter packages
+#
+# Filter packages that should be keep in the inventory.
+# Use the rich filter language describe in documentation.
+#       English version: https://support.zeenea.com/en/support/solutions/articles/44002389524-filters
+#       French  version: https://support.zeenea.com/fr/support/solutions/articles/44002389524-filtres
+#
+# filter keys are:
+#   package: package also known as file names that ends with .dtsx.
+#
+# Example:
+#   filter = "package in ('production-pack01', 'production-pack02')"
+#
+# Note:
+#   Filter can contain either the raw value or a file URL to the content.
+#   Example:
+#     filter = "file:///path/to/zeenea/connections/ssis-filter.json"
+#
+# When using an side-file, filter changes are taken into account without restarting the scanner.
+#
+# filter = ""


### PR DESCRIPTION
Ajoute une explication sur la nouvelle clé de configuration du connecteur ssis `filter`. Cette pull request est la conséquence de :
- zeenea/sqlserver-services-connector-plugin#10